### PR TITLE
Create tests for list_all_notes

### DIFF
--- a/scripts/user.py
+++ b/scripts/user.py
@@ -16,7 +16,7 @@ class User:
     def list_all_notes(self):
         """Method to list all notes in a github repository."""
         repo = self.auth.get_user().get_repo("octomemo_" + self._login)
-        print("Avaiable notes:")
+        print("Available notes:")
         for file in repo.get_dir_contents(""):
             print(file.name)
 

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -1,11 +1,41 @@
 # -*- coding: utf-8 -*-
-from unittest import TestCase
+from unittest import TestCase, mock
+from unittest.mock import Mock
+
+from pytest import fixture
+
 from scripts.user import User
 
 
 class TestUser(TestCase):
+    @fixture(autouse=True)
+    def _pass_fixtures(self, capsys):
+        self.capsys = capsys
+
     def setUp(self):
         TestCase.setUp(self)
 
     def test_create_repo(self):
         self.assertTrue(True)
+
+    @mock.patch('github.Github.get_user')
+    def test_list_all_notes(self, mock_get_user: mock.Mock):
+        user = User("login", "password")
+        expected_file_name = "code_file.txt"
+        mock_repo = self.get_mocked_github_repo(expected_file_name)
+        mock_github = Mock()
+        mock_github.get_repo.return_value = mock_repo
+        mock_get_user.return_value = mock_github
+
+        user.list_all_notes()
+
+        captured = self.capsys.readouterr()
+        self.assertTrue("Available notes:" in captured.out)
+        self.assertTrue(expected_file_name in captured.out)
+
+    def get_mocked_github_repo(self, expected_file_name):
+        mock_file = Mock()
+        mock_file.name = expected_file_name
+        mock_repo = Mock()
+        mock_repo.get_dir_contents.return_value = [mock_file]
+        return mock_repo

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -20,7 +20,8 @@ class TestUser(TestCase):
 
     @mock.patch('github.Github.get_user')
     def test_list_all_notes(self, mock_get_user: mock.Mock):
-        user = User("login", "password")
+        login_name = "login"
+        user = User(login_name, "password")
         expected_file_name = "code_file.txt"
         mock_repo = self.get_mocked_github_repo(expected_file_name)
         mock_github = Mock()
@@ -32,6 +33,8 @@ class TestUser(TestCase):
         captured = self.capsys.readouterr()
         self.assertTrue("Available notes:" in captured.out)
         self.assertTrue(expected_file_name in captured.out)
+        mock_github.get_repo.assert_called_with("octomemo_" + login_name)
+        mock_repo.get_dir_contents.assert_called_with("")
 
     def get_mocked_github_repo(self, expected_file_name):
         mock_file = Mock()


### PR DESCRIPTION
The other PR someone submitted wasn't actually tests for the function, they just added code. So where we make an actual unit test for list_all_notes. 

We mock githubs response when we call get_repo to return a list of mocked files... and then we test that the file names were printed to std.out. We also verify the parameters that github methods are called with