### PR TITLE
Create repo if it does not exist

### DIFF
--- a/scripts/user.py
+++ b/scripts/user.py
@@ -2,26 +2,40 @@ from github import Github, GithubException
 import base64
 import os
 
-
 class User:
     def __init__(self, login, password):
         self._login = login
         self._password = password
         self.auth = Github(login, password)
+        self.repo = self.get_repo()
 
     def create_repo(self):
         """Method to create a repository for notes."""
-        self.auth.get_user().create_repo("octomemo_" + self._login, private=True)
+        return self.auth.get_user().create_repo("octomemo_" + self._login, private=True)
+
+    def get_repo(self):
+        """ Gets the repo if exists, create it if not """
+        repo_name = self._login
+
+        if '@' in repo_name:
+            repo_name = repo_name.replace('@', '-')
+
+        try:
+            repo = self.auth.get_user().get_repo("octomemo_" + repo_name)
+            return repo
+        except GithubException as error:
+            if error.data.get('message') == 'Not Found':
+                return self.create_repo()
+            raise
 
     def list_all_notes(self):
         """Method to list all notes in a github repository."""
+        print("Available notes:")
         try:
-            repo = self.auth.get_user().get_repo("octomemo_" + self._login)
-            print("Available notes:")
-            for file in repo.get_dir_contents(""):
+            for file in self.repo.get_dir_contents(""):
                 print(file.name)
-        except GithubException:
-            print("Repo not found")
+        except GithubException as error:
+           print(error.data.get('message'))
 
     def create_note(self, name, message="none", content=""):
         """Method to create a note in a github repository.
@@ -30,8 +44,7 @@ class User:
         :param str message: Commit message
         :param str content: Note content
         """
-        repo = self.auth.get_user().get_repo("octomemo_" + self._login)
-        repo.create_file(name, message, content)
+        self.repo.create_file(name, message, content)
 
     def delete_note(self, name, message="deleting file"):
         """Method to delete a note in a github repository.
@@ -39,8 +52,7 @@ class User:
         :param str name: Name of note to be deleted
         :param str message: Commit message
         """
-        repo = self.auth.get_user().get_repo("octomemo_" + self._login)
-        sha = repo.get_contents(name).sha
+        sha = self.repo.get_contents(name).sha
         repo.delete_file(name, message, sha)
 
     def edit_note(self, name):
@@ -48,8 +60,7 @@ class User:
 
         :param str name: Name of note to be deleted
         """
-        repo = self.auth.get_user().get_repo("octomemo_" + self._login)
-        file = repo.get_contents(name)
+        file = self.repo.get_contents(name)
         text = base64.b64decode(file.content).decode("utf-8")
         f = open(name, "w+")
         f.write(text)


### PR DESCRIPTION
Hi there, I've checked this repo and I encounted the following problem when trying to use it.

Altough an exception is being raised when repo doesn't exist, there was no way to use the create_repo method from User from command line.

So I added the next behavior.

- When instantiating the User it goes through a common method to get the repo, if it doesn't exist it creates it and stored as a User property (That way it would work for any method).

Also I found another problem:

- When you try to use your email to log in Github transform the "@" character to a "-". So I manage this case when getting the repo.

I've also added a test case for the repo creation based on existing test.

This project sound as a good idea, if you think anything should be changed I'll be aware of it.

Greetings from Mexico!
